### PR TITLE
Fix for file names with spaces or symbols in them

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -103,7 +103,7 @@ async function splitImages () {
     let str = '';
     let done = 0;
     let w, h, numTiles;
-    const prefix = prefixInput.value || file.name.replace(/\.\w+$/, '');
+    const prefix = (prefixInput.value || file.name).replace(/\.\w+$/, '').replace(" ", "_").replace(/[^A-Za-z0-9_]/g, '');
     const zip = new JSZip();
     const startTime = Date.now();
 

--- a/js/main.js
+++ b/js/main.js
@@ -103,7 +103,7 @@ async function splitImages () {
     let str = '';
     let done = 0;
     let w, h, numTiles;
-    const prefix = (prefixInput.value || file.name).replace(/\.\w+$/, '').replace(" ", "_").replace(/[^A-Za-z0-9_]/g, '');
+    const prefix = (prefixInput.value || file.name.replace(/\.\w+$/, '')).replace(/\s+/g, '_').replace(/[^\w]/g, '');
     const zip = new JSZip();
     const startTime = Date.now();
 


### PR DESCRIPTION
File names with spaces or symbols in them would yield invalid text to paste from the emojis.txt file. With a couple replace's it works again.