### PR TITLE
Allow naming zip as prefix

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,12 @@
                         <i class="fas fa-times"></i>
                     </label>
                     <input type="checkbox" id="shrink">
+                    <label for="namezip">
+                        Use prefix as zip name?
+                        <i class="fas fa-check"></i>
+                        <i class="fas fa-times"></i>
+                    </label>
+                    <input type="checkbox" id="namezip">
 
                     <input type="submit" value="Split" id="submit">
                 </form>

--- a/js/main.js
+++ b/js/main.js
@@ -24,13 +24,12 @@ function init () {
     txt = $('textarea');
     previewDiv = $('div');
     prev = $('td#preview');
-    shrinkCheck = $('i.fa-check');
-    shrinkCross = $('i.fa-times');
     fileInfo = $('em');
 
     form = $('form');
     prefixInput = $('input#prefix');
     shrinkInput = $('input#shrink');
+    namezipInput = $('input#namezip');
     delayInput = $('input#delay');
     fileInput = $('input#file');
     sizeInput = $('input#size');
@@ -45,6 +44,7 @@ function init () {
 
     form.addEventListener('submit', e => e.preventDefault());
     shrinkInput.addEventListener('click', toggleShrink);
+    namezipInput.addEventListener('click', toggleShrink);
     addEventListeners();
     toggleShrink();
 }
@@ -57,8 +57,21 @@ function addEventListeners () {
     fileInput.addEventListener('change', handleFileChange);
 }
 
-function toggleShrink () {
-    if (shrinkInput.checked) {
+function toggleShrink(e) {
+    if (e == null) {
+        $('input#shrink').checked = false;
+        $('label[for=shrink] > i.fa-check').style.display = 'none';
+        $('label[for=shrink] > i.fa-times').style.display = '';
+        $('input#namezip').checked = true;
+        $('label[for=namezip] > i.fa-times').style.display = 'none';
+        $('label[for=namezip] > i.fa-check').style.display = '';
+        return;
+    }
+    var target = e.target;
+    var shrinkCheck = $(`label[for=${target.id}] > i.fa-check`);
+    var shrinkCross = $(`label[for=${target.id}] > i.fa-times`);
+
+    if (target.checked) {
         shrinkCheck.style.display = '';
         shrinkCross.style.display = 'none';
     } else {
@@ -74,8 +87,13 @@ function handleFileChange () {
     delayLabel.style.display = delayInput.style.display = file.name.endsWith('.gif') ? '' : 'none';
 }
 
-function save () {
-    saveAs(currentZip, 'emojis.zip');
+function save (prefix) {
+    console.log("called save");
+    if (namezipInput.checked) {
+        saveAs(currentZip, `${prefix}.zip`);
+    } else {
+        saveAs(currentZip, 'emojis.zip');
+    }
 }
 
 function resize (img, w, h) {
@@ -302,8 +320,8 @@ async function splitImages () {
     timeTaken.innerText = `Time taken: ${ Date.now() - startTime }ms`;
     submit.value = 'Split';
 
-    download.removeEventListener('click', save);
-    download.addEventListener('click', save);
+    download.removeEventListener('click', function(){save(prefix)});
+    download.addEventListener('click', function(){save(prefix)});
 
     addEventListeners();
 }

--- a/js/main.js
+++ b/js/main.js
@@ -59,12 +59,11 @@ function addEventListeners () {
 
 function handleCheckboxes(e) {
     if (e == null) {
-        $('input#shrink').checked = false;
-        $('label[for=shrink] > i.fa-check').style.display = 'none';
-        $('label[for=shrink] > i.fa-times').style.display = '';
-        $('input#namezip').checked = true;
-        $('label[for=namezip] > i.fa-times').style.display = 'none';
-        $('label[for=namezip] > i.fa-check').style.display = '';
+        document.querySelectorAll('input[type=checkbox]').forEach((e) => {
+            $(`input#${e.id}`).checked = (e.id == 'namezip' ? true : false);
+            $(`label[for=${e.id}] > i.fa-check`).style.display = (e.id == 'namezip' ? '' : 'none');
+            $(`label[for=${e.id}] > i.fa-times`).style.display = (e.id == 'namezip' ? 'none' : '');
+        });
         return;
     }
     var target = e.target;

--- a/js/main.js
+++ b/js/main.js
@@ -43,10 +43,10 @@ function init () {
     delayLabel.style.display = delayInput.style.display = 'none';
 
     form.addEventListener('submit', e => e.preventDefault());
-    shrinkInput.addEventListener('click', toggleShrink);
-    namezipInput.addEventListener('click', toggleShrink);
+    shrinkInput.addEventListener('click', handleCheckboxes);
+    namezipInput.addEventListener('click', handleCheckboxes);
     addEventListeners();
-    toggleShrink();
+    handleCheckboxes();
 }
 
 const toBlob = (d) => new Promise((res) => d.toBlob(res));
@@ -57,7 +57,7 @@ function addEventListeners () {
     fileInput.addEventListener('change', handleFileChange);
 }
 
-function toggleShrink(e) {
+function handleCheckboxes(e) {
     if (e == null) {
         $('input#shrink').checked = false;
         $('label[for=shrink] > i.fa-check').style.display = 'none';

--- a/js/main.js
+++ b/js/main.js
@@ -320,7 +320,9 @@ async function splitImages () {
     timeTaken.innerText = `Time taken: ${ Date.now() - startTime }ms`;
     submit.value = 'Split';
 
-    download.removeEventListener('click', function(){save(prefix)});
+    newDownload = download.cloneNode(true);
+    download.parentNode.replaceChild(newDownload, download);
+    download = newDownload;
     download.addEventListener('click', function(){save(prefix)});
 
     addEventListeners();

--- a/style.css
+++ b/style.css
@@ -124,12 +124,12 @@ label {
     font-size: 0.95rem;
 }
 
-input#shrink {
+input:is(#shrink, #namezip) {
     opacity: 0;
     position: absolute;
 }
 
-label[for="shrink"] {
+label:is([for="shrink"], [for="namezip"]) {
     cursor: pointer;
     user-select: none;
 }


### PR DESCRIPTION
Is default behaviour. Made default [here](https://github.com/xllifi/image-splitter/blob/e8fc4f1618b019060c5aa383b0b4f6a54e7fec3b/js/main.js#L65), if you want to change it.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a feature to allow users to name the zip file using a prefix through a new checkbox option in the UI. Refactor the toggleShrink function to accommodate this new feature and improve code maintainability.

New Features:
- Introduce a new checkbox option in the UI to allow users to use a prefix as the zip file name when saving.

Enhancements:
- Refactor the toggleShrink function to handle multiple checkbox inputs, including the new 'namezip' option.

<!-- Generated by sourcery-ai[bot]: end summary -->